### PR TITLE
fix(store): make the MSIX submittable; release v0.6.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,13 +287,26 @@ jobs:
           gh release upload "$GITHUB_REF_NAME" airclone-windows-x64.zip --clobber --repo "$GITHUB_REPOSITORY"
           gh release upload "$GITHUB_REF_NAME" windows/installer/airclone-setup-x64.exe --clobber --repo "$GITHUB_REPOSITORY"
       # MSIX for the Microsoft Store. --store => unsigned, Partner-Center-ready
-      # (the Store signs it), so no certificate and no interactive prompt. Identity
-      # comes from pubspec's msix_config (placeholders until the app is registered
-      # in Partner Center). Non-fatal: a Store package is optional and must never
-      # break the release.
+      # (the Store signs it), so no certificate and no interactive prompt.
+      #
+      # IDENTITY comes from repo variables, NOT pubspec — Package/Identity/Publisher
+      # is a Partner-Center-assigned GUID and this repo is public. pubspec keeps
+      # inert placeholders so local builds still work; these three override them:
+      #   MSIX_IDENTITY_NAME  -> Package/Identity/Name       (reserved package name)
+      #   MSIX_PUBLISHER      -> Package/Identity/Publisher  (CN=<GUID>)
+      #   MSIX_DISPLAY_NAME   -> Package/Properties/DisplayName (must be a RESERVED
+      #                          app name; also becomes the Start-menu tile, since
+      #                          msix drives both from one displayName)
+      # All must match Partner Center → Product management → Product identity
+      # EXACTLY, or the upload is rejected before certification starts.
+      # Non-fatal: a Store package is optional and must never break the release.
       - name: Build MSIX (Microsoft Store package)
         continue-on-error: true
         shell: pwsh
+        env:
+          MSIX_IDENTITY_NAME: ${{ vars.MSIX_IDENTITY_NAME }}
+          MSIX_PUBLISHER: ${{ vars.MSIX_PUBLISHER }}
+          MSIX_DISPLAY_NAME: ${{ vars.MSIX_DISPLAY_NAME }}
         run: |
           # Refuse to build an engine-less Store package. The "Bundle rclone" step above
           # is now FATAL (v0.5.3 fix), so rclone.exe is guaranteed present by the time we
@@ -305,7 +318,36 @@ jobs:
             throw "rclone.exe was not bundled into $rel (bundle step failed) — refusing to build an engine-less Store MSIX."
           }
           $ver = ((Select-String -Path pubspec.yaml -Pattern '^version:' | Select-Object -First 1).Line -split ':')[1].Trim().Split('+')[0]
-          dart run msix:create --store --version "$ver.0" --build-windows false --output-path . --output-name airclone
+          # Override the pubspec placeholders with the real Partner Center identity.
+          # A missing variable is loud: the package still builds (useful for testing
+          # the payload) but is NOT submittable, and silence here is exactly how the
+          # v0.6.0 package shipped with placeholder identity in the first place.
+          $identity = @()
+          $missing = @()
+          foreach ($v in @(
+            @{ env = 'MSIX_IDENTITY_NAME'; flag = '--identity-name' },
+            @{ env = 'MSIX_PUBLISHER';     flag = '--publisher' },
+            @{ env = 'MSIX_DISPLAY_NAME';  flag = '--display-name' })) {
+            $val = [Environment]::GetEnvironmentVariable($v.env)
+            if ([string]::IsNullOrWhiteSpace($val)) { $missing += $v.env }
+            else { $identity += @($v.flag, $val) }
+          }
+          if ($missing.Count -gt 0) {
+            Write-Output "::warning::MSIX identity variable(s) not set: $($missing -join ', '). The package will carry pubspec PLACEHOLDER identity and Partner Center will reject it. Set them under Settings → Secrets and variables → Actions → Variables."
+          } else {
+            Write-Output "MSIX identity supplied from repo variables (name + publisher + display name)."
+          }
+          dart run msix:create --store --version "$ver.0" --build-windows false --output-path . --output-name airclone @identity
+      # Also publish the MSIX as a run artifact, so a workflow_dispatch run can
+      # produce a corrected Store package (e.g. after an identity fix) WITHOUT
+      # minting a new tag/release. The release upload below is tag-only.
+      - name: Upload MSIX artifact
+        if: hashFiles('app/airclone.msix') != ''
+        continue-on-error: true
+        uses: actions/upload-artifact@v4
+        with:
+          name: airclone-msix
+          path: app/airclone.msix
       - name: Upload MSIX to release
         if: startsWith(github.ref, 'refs/tags/')
         continue-on-error: true

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.6.0+109
+version: 0.6.1+110
 
 environment:
   sdk: ^3.12.0
@@ -177,19 +177,31 @@ flutter:
 # --store for a Partner-Center-uploadable, Store-signed package). The version is
 # overridden per-release by CI (--version <x.y.z>.0).
 #
-# BEFORE submitting to the Store, replace the two identity placeholders with the
-# real values from Partner Center → your app → Product management → Product
-# identity:
-#   * identity_name       = the reserved Package/Identity Name (e.g. 1234GigaionLLC.Airclone)
-#   * publisher           = the assigned Publisher ID (CN=<GUID>)
-#   * publisher_display_name = must match the Store publisher display name
-# Until then this still builds a structurally valid (but not-yet-submittable) package.
+# Store identity is validated on UPLOAD, before certification even starts, and a
+# mismatch is a hard "Package acceptance validation error". None of it comes from a
+# signing certificate — `--store` packages are unsigned and Microsoft signs them;
+# the values must match Partner Center → Product management → Product identity.
+#
+# `identity_name`, `publisher` and `display_name` below are deliberately INERT
+# PLACEHOLDERS. The real ones are injected by release.yml from the repo variables
+# MSIX_IDENTITY_NAME / MSIX_PUBLISHER / MSIX_DISPLAY_NAME, because
+# Package/Identity/Publisher is a Partner-Center-assigned GUID and this repo is
+# public. A local `dart run msix:create` therefore produces a package that INSTALLS
+# fine for testing but is NOT submittable — that is intended.
+#
+# `publisher_display_name` is the real value: it is the company name, already public
+# throughout this repo (installer AppPublisher, code-signing subject), and is not a
+# GUID. It was rejected as the placeholder "GigaionLLC" on the first v0.6.0 upload.
+#
+# Gotcha: msix drives BOTH Package/Properties/DisplayName and the Start-menu tile
+# (uap:VisualElements/@DisplayName) from `display_name`, so MSIX_DISPLAY_NAME must be
+# a RESERVED app name and is also what users see on the tile.
 msix_config:
   display_name: Airclone
-  publisher_display_name: GigaionLLC
-  identity_name: GigaionLLC.Airclone
-  publisher: CN=GigaionLLC
-  msix_version: 0.5.0.0
+  publisher_display_name: "Gigaion, LLC"
+  identity_name: PLACEHOLDER.SetMsixIdentityNameVar
+  publisher: CN=PLACEHOLDER-SET-MSIX-PUBLISHER-VAR
+  msix_version: 0.6.1.0
   logo_path: ../docs/brand/airclone-icon-1024.png
   capabilities: internetClient
   # `dart run msix:create --store` (used in CI) produces an unsigned,

--- a/dev/releases/v0.6.1.md
+++ b/dev/releases/v0.6.1.md
@@ -1,0 +1,31 @@
+# Airclone v0.6.1 — Microsoft Store packaging fix
+
+**Nothing in the app changed.** If you already run v0.6.0, there is no reason to
+update: the Windows, macOS, Linux and Android builds here are the same
+application, rebuilt. This release exists so the Microsoft Store package carries
+the right identity.
+
+## Microsoft Store
+
+- **The Store package (`airclone.msix`) now declares its real identity.** The
+  package name, publisher, display name and publisher display name had never
+  been changed from the placeholders written when the MSIX lane was first wired,
+  so the Store rejected the package on upload before certification could even
+  start. All four now come from the Partner Center reservation.
+- **They can no longer drift.** The identity is injected by CI from repository
+  variables rather than living in the build config, and a build that is missing
+  them now says so loudly instead of quietly producing a package that cannot be
+  submitted.
+- The v0.6.0 `airclone.msix` asset is superseded by this one. Nothing else about
+  that release was affected — its installers and binaries were, and remain,
+  correct.
+
+## Notes
+
+- Same as v0.6.0 otherwise: Windows `airclone.exe` + installer are code-signed
+  (Gigaion, LLC) and bundle a verified rclone **v1.75.0** engine; macOS is
+  Developer ID signed + notarized; Android APKs are release-signed.
+- **Known limitation, unchanged from v0.6.0:** video *playback* is verified on
+  desktop but could not be verified on Android hardware — the emulator cannot
+  render video and no physical device was available. The preview *failure* paths
+  are verified on Android; the success path is not.

--- a/dev/windows-signing-and-store.md
+++ b/dev/windows-signing-and-store.md
@@ -198,17 +198,25 @@ download reputation (days–weeks); an **EV** profile is trusted instantly.
 
 ## 2. Microsoft Store — company account + per-release submission
 
-> **PATH DECISION (2026-07-23): we ship as an UNPACKAGED Win32 EXE app, NOT MSIX.**
-> The "Airclone" app in Partner Center is the **EXE/MSI** product type — you host your
-> own **signed** installer at a **direct (non-redirecting) URL** and the Store points at
-> it. This reuses the `airclone-setup-x64.exe` we already build + sign and needs no MSIX
-> identity plumbing. The `--store` MSIX is still built by CI (a possible future pivot /
-> winget) but is NOT what we submit. §2a (account) still applies; **§§2b–2g are the
-> ORIGINAL, now-SUPERSEDED MSIX plan**, kept only for reference.
+> **PATH DECISION (2026-08-08): we ship as an MSIX again.** This REVERSES the
+> 2026-07-23 EXE/MSI decision quoted below. Reason: only a *packaged* product has
+> Store commerce, so the Store collects the listing fee and **no payment code ever
+> enters this open-source app**. The EXE/MSI product type shows only "Download" and
+> its pricing dropdown is inert metadata. Submissions now go to the packaged
+> reservation **"Airclone: Cloud File Manager"** (`GigaionLLC.AircloneCloudFileManager`).
+> §§2b–2g below are LIVE again; see §2c for the identity plumbing, which is now real.
 >
-> **Keep `STORE_PUBLISH_ENABLED` UNSET / false permanently** — the CI "Submit MSIX to Microsoft Store"
-> step (`msstore publish`) targets the superseded MSIX and does NOT fit the EXE product type now used
-> in Partner Center; turning it on would publish the wrong package.
+> `STORE_PUBLISH_ENABLED` may be turned on once a manual submission has succeeded
+> end-to-end — the `msstore publish` step targets the MSIX, which is again correct.
+>
+> <details><summary>Superseded 2026-07-23 decision (EXE/MSI), kept for context</summary>
+>
+> We ship as an UNPACKAGED Win32 EXE app, NOT MSIX. The "Airclone" app in Partner
+> Center is the EXE/MSI product type — you host your own signed installer at a direct
+> (non-redirecting) URL and the Store points at it. This reuses the
+> `airclone-setup-x64.exe` we already build + sign and needs no MSIX identity plumbing.
+> Keep `STORE_PUBLISH_ENABLED` unset; `msstore publish` would publish the wrong package.
+> </details>
 
 ### Per-release submission runbook (EXE path) — do this for every Store update
 
@@ -326,6 +334,43 @@ transfer commands, for example:
 NO OTHER SOFTWARE IS REQUIRED
 The installer contains the full rclone engine and the Microsoft Visual C++ runtime
 files. Nothing is downloaded on first run.
+```
+
+**D3. Restricted capability justification (MSIX only)** — Submission Options → *Restricted
+capabilities* asks why the package declares `runFullTrust`. This is a REQUIRED free-text
+field on every packaged submission, not an error: `msix` emits
+`<rescap:Capability Name="runFullTrust"/>` for any Flutter/Win32 app because the entry
+point is `Windows.FullTrustApplication`. Do NOT try to remove it — the app cannot run
+without it. Paste verbatim:
+
+```
+Airclone is a Win32 desktop application (Flutter + C++) packaged for the Store with the
+Desktop Bridge. Its application entry point is Windows.FullTrustApplication, which
+requires runFullTrust. The capability is not used to reach anything beyond what the
+app's own features need, and the app collects no user data.
+
+1. GENERAL-PURPOSE FILE MANAGEMENT
+Airclone is a file manager. It browses, copies, moves, renames and deletes files the
+user chooses across their local disks, network locations and connected cloud storage,
+including whole-folder transfers between two locations. This needs broad file-system
+access; the brokered file-picker model cannot express "list every drive and folder,
+then copy this tree to another location".
+
+2. THE BUNDLED RCLONE ENGINE RUNS AS A CHILD PROCESS
+Airclone is a graphical front end for the open-source tool rclone. The package ships
+its own copy of the engine (rclone.exe, plus librclone.dll for in-process use) and
+starts it as a local child process, communicating with it over an HTTP RPC endpoint
+bound to 127.0.0.1 only. Creating a child process and loading these native libraries
+requires full trust. No executable code is downloaded at runtime - the engine is
+bundled in the package and version-pinned.
+
+3. NATIVE MEDIA AND DOCUMENT COMPONENTS
+File preview loads native libraries in-process: libmpv for video and audio, PDFium for
+PDF, and the Windows shell integration used for drag-and-drop and "open in another app".
+
+Airclone has no accounts, no telemetry and no servers of ours. All processing happens
+on the user's device, and cloud credentials stay in the user's own rclone configuration
+file on that machine.
 ```
 
 **E. Properties / Age ratings / Availability** — Category *Utilities & tools › Backup &
@@ -446,14 +491,47 @@ then open the app → **Product management → Product identity** and copy:
 - **Publisher display name** (e.g. `Gigaion, LLC`)
 - the **Store ID** (the product id)
 
-### 2c. Put the real identity in the package
-Edit `app/pubspec.yaml` → `msix_config` (today placeholders
-`identity_name: GigaionLLC.Airclone` / `publisher: CN=GigaionLLC`):
-- `identity_name`          = the reserved **Package/Identity Name**
-- `publisher`              = the assigned **Publisher** (`CN=<GUID>`)
-- `publisher_display_name` = must match the Store **publisher display name**
+### 2c. Put the real identity in the package  (via REPO VARIABLES, not pubspec)
+`Package/Identity/Publisher` is a Partner-Center-assigned GUID and this repo is
+public, so the real identity is injected by `release.yml` from repo variables and
+`app/pubspec.yaml` keeps inert `PLACEHOLDER.*` values. Set all three:
 
-A `--store` package only uploads once its identity matches the reserved app.
+```powershell
+gh variable set MSIX_IDENTITY_NAME --repo GigaionLLC/Airclone --body "<Package/Identity/Name>"
+gh variable set MSIX_PUBLISHER     --repo GigaionLLC/Airclone --body "CN=<GUID>"
+gh variable set MSIX_DISPLAY_NAME  --repo GigaionLLC/Airclone --body "<a RESERVED app name>"
+```
+
+Copy the values verbatim from **Product management → Product identity**. If any
+variable is unset the build still runs but emits a `::warning::` and produces a
+package Partner Center WILL reject — that silence is exactly how v0.6.0 shipped
+with placeholder identity. `publisher_display_name` stays in pubspec (`Gigaion, LLC`):
+it is the company name, already public throughout this repo, and is not a GUID.
+
+Four fields are validated on upload, and **the first failure masks the rest** — fix
+them as a set, not one round-trip each:
+
+| Manifest | Source |
+|---|---|
+| `Package/Identity/Name` | reserved package name |
+| `Package/Identity/Publisher` | assigned Publisher ID (`CN=<GUID>`) |
+| `Package/Properties/DisplayName` | must be a **reserved app name** |
+| `Package/Properties/PublisherDisplayName` | Store publisher display name |
+
+The **package family name** is not a field — it is derived as
+`<Identity/Name>_<base32(SHA-256(Publisher as UTF-16LE)[0..7])>` using the alphabet
+`0123456789abcdefghjkmnpqrstvwxyz`. Computing it locally is a fast way to prove a
+publisher string is byte-exact before uploading 95 MB.
+
+Gotcha: `msix` drives BOTH `Package/Properties/DisplayName` and the Start-menu tile
+(`uap:VisualElements/@DisplayName`) from one `display_name`, so `MSIX_DISPLAY_NAME`
+is also what users see on the tile. Reserving a short name (Product management →
+**Manage app names**) is the only way to get a short tile.
+
+A `--store` package only uploads once its identity matches the reserved app. Because
+`--store` packages are UNSIGNED, a wrong identity can be corrected without rebuilding:
+`makeappx unpack` → edit `AppxManifest.xml` → delete `AppxBlockMap.xml` →
+`makeappx pack` (it regenerates the block map).
 
 ### 2d. API credentials for automated submission
 1. Create (or reuse the §1 signing) **Entra app registration**; note tenant id, client
@@ -501,10 +579,19 @@ complete); turn it on later for tag-triggered updates.
 | Publisher display name | **Gigaion, LLC** (must match `msix_config.publisher_display_name`) |
 | Public Store-contact address | a **PO Box** (the registered legal address failed with `PremisesPartial`) |
 | Company website / support | `https://gigaion.com` |
-| Package/Identity Name | _tbd — after verification + app reservation_ |
-| Publisher (`CN=<GUID>`) | _tbd_ |
+| Reserved product | **Airclone: Cloud File Manager** (packaged/MSIX reservation, 2026-08-08) |
+| Package/Identity Name | `GigaionLLC.AircloneCloudFileManager` |
+| Publisher (`CN=<GUID>`) | in repo variable `MSIX_PUBLISHER` — **never commit the GUID** |
+| Reserved app names | only the full title so far; "Airclone" alone is NOT reserved, so the Start-menu tile carries the full title unless it is reserved too |
 | Store ID | _tbd_ |
 | Seller ID | _tbd_ |
+
+**v0.6.0 upload (2026-08-08) — rejected 4×, all identity, all from never replacing the
+2026-07-12 placeholders.** Partner Center reported only the `PublisherDisplayName`
+mismatch first; fixing it revealed the other three. The shipped `airclone.msix` asset on
+the v0.6.0 release still carries the placeholder identity — the submitted package was
+hand-corrected with `makeappx` (§2c). CI now injects identity from repo variables, so
+this cannot recur silently.
 
 ---
 

--- a/docs/store/play/whats-new-v0.6.0.md
+++ b/docs/store/play/whats-new-v0.6.0.md
@@ -1,0 +1,58 @@
+# Google Play — "What's new" (en-US) — v0.6.0
+
+Paste-ready copy for the Play Console release notes field.
+
+Still current for the **v0.6.1** build: v0.6.1 changed only the Microsoft Store
+package identity, so the Android app is byte-for-byte the same feature set and
+these notes describe it accurately whichever of the two AABs is uploaded.
+
+**Limit: 500 characters per language.** Play counts every character including
+newlines and the `•` bullets. Keep a version under the limit *before* pasting —
+the Console truncates silently in some browsers.
+
+Android-only: desktop-only changes from `dev/releases/v0.6.0.md` (the close-with-
+mounts warning, the resizable desktop preview, the "Update engine" fix) are
+deliberately left out — the Android engine ships inside the app and is never
+updated in-app.
+
+---
+
+## Recommended (fits the limit)
+
+```
+Better previews, and files that open anywhere.
+
+• A video that can't play now tells you why, with Try again or Open in another app.
+• Photos and videos open full screen. Swipe between them, tap to hide controls.
+• Open any file in another app, or send it with the share sheet.
+• Thumbnails no longer stutter the video you're watching.
+• Every desktop tool is now on your phone, under ⋯ → Advanced.
+• Fixed the tablet toolbar overlapping the status bar.
+• Built-in rclone engine updated to v1.75.0.
+```
+
+## Shorter alternative
+
+If you'd rather lead with the review that prompted this release:
+
+```
+You told us video previews often didn't work. Fixed — and then some.
+
+• A failed video now says why, with Try again or Open in another app.
+• Photos and videos open full screen, swipe to move between them.
+• Open any file in another app, or share it.
+• Thumbnails no longer stutter playback.
+• All the desktop tools, now on phone (⋯ → Advanced).
+• Fixed the tablet toolbar overlapping the status bar.
+• rclone engine updated to v1.75.0.
+```
+
+---
+
+## Notes
+
+- Both versions avoid claiming video playback is *fixed on all devices*. The
+  failure paths are verified on Android; the success path could not be verified
+  on hardware (see `dev/releases/v0.6.0.md`). Saying "a video that can't play now
+  tells you why" is true and is the actual change.
+- Don't add pricing or "free" claims here — same rule as the listing.


### PR DESCRIPTION
Makes the Microsoft Store package submittable, and cuts v0.6.1 so CI produces one.

**No application changes.** Every platform build here is v0.6.0 rebuilt.

### What was wrong
The v0.6.0 `airclone.msix` was rejected on upload - before certification started - on
all four identity fields. The placeholders written when the MSIX lane was first wired
(09ad2a0, 2026-07-12) were never replaced. The correct publisher display name had been
recorded in `dev/windows-signing-and-store.md` the whole time; nothing forced the
config to agree with it.

Partner Center reports only the **first** failing field, so this surfaced one error at a
time - fix the display name, discover three more.

### What changed
- Identity now comes from repo variables `MSIX_IDENTITY_NAME` / `MSIX_PUBLISHER` /
  `MSIX_DISPLAY_NAME`, not pubspec, because `Package/Identity/Publisher` is a Partner
  Center GUID and this repo is public. Verified: the GUID appears in no tracked file.
- A missing variable emits a `::warning::` and produces an unsubmittable package.
  Silence is exactly how v0.6.0 shipped with placeholder identity.
- `publisher_display_name` stays in pubspec - company name, already public across the
  repo, not a GUID.
- New `airclone-msix` run artifact, so `workflow_dispatch` can produce a corrected
  package without minting a tag. The release upload is tag-only, which is why there was
  no way to get a fixed MSIX short of a new release.
- Docs: reverses the 2026-07-23 "EXE/MSI, not MSIX" decision (kept collapsed for
  context), rewrites 2c, and adds D3 - the `runFullTrust` justification Partner Center
  requires on every packaged submission.
- Play "What's new" copy, measured against the 500-char cap.

### Verification
A hand-corrected package built by `makeappx` unpack/repack was **accepted by Partner
Center**, which is what confirms these exact values. The publisher string was proven
byte-exact by computing the package family name
(`base32(SHA-256(publisher as UTF-16LE)[0..7])`) and matching Partner Center's
expected `_6gejzjmmbst2w` - the same computation reproduces the rejected
`_eb73kxgwkjhhy` from the old placeholder, so the method is sound.

The three repo variables are already set and round-trip verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)